### PR TITLE
Fix rounding error in depreciation value using decimal arithmetic

### DIFF
--- a/auto_depreciation.py
+++ b/auto_depreciation.py
@@ -41,7 +41,7 @@ def auto_depreciation(entries, options_map, config=None):
     DEFAULT_ASSETS_ACCOUNT = 'Assets:Wealth:Fixed-Assets'
     DEFAULT_EXPENSES_ACCOUNT = 'Expenses:Property-Expenses:Depreciation'
     DEFAULT_METHOD = 'parabola'
-    DEFAULT_RESIDUAL_VALUE = 0.0
+    DEFAULT_RESIDUAL_VALUE = Decimal(0)
     try:
         config_dict = eval(config)
     except (TypeError, SyntaxError):
@@ -71,9 +71,9 @@ def auto_depreciation(entries, options_map, config=None):
                         and posting.account == assets_account):
                     cost = posting.cost
                     currency = cost.currency
-                    original_value = float(cost.number)
+                    original_value = cost.number
                     try:
-                        end_value = float(posting.meta['residual_value'])
+                        end_value = posting.meta['residual_value']
                     except KeyError:
                         end_value = DEFAULT_RESIDUAL_VALUE
                     label = cost.label
@@ -108,9 +108,9 @@ def depreciation_list(start_value, end_value, buy_date, months, method):
     
     Parameters
     ----------
-    start_value : float
+    start_value : Decimal
         Original value.
-    end_value : float
+    end_value : Decimal
         residual value.
     buy_date : datetime.date
         The date you buy the assets.
@@ -139,7 +139,7 @@ def depreciation_list(start_value, end_value, buy_date, months, method):
     days_list = [(x - buy_date).days for x in dates_list]
     depreciation_days = days_list[-1]
     current_values = [
-        get_current_value(x, start_value, end_value, depreciation_days)
+        get_current_value(x, float(start_value), float(end_value), depreciation_days)
         for x in days_list
     ]
     depreciation_values = []

--- a/auto_depreciation_test.py
+++ b/auto_depreciation_test.py
@@ -61,12 +61,12 @@ class TestExampleAutoDepreciation(cmptest.TestCase):
         2020-04-30 * "Test-auto_depreciation:Nikon"
           Assets:Fixed-Assets   -2 LENS {600.00 CNY, 2020-03-31, "Nikon"}
           Assets:Fixed-Assets    2 LENS {380 CNY, 2020-04-30, "Nikon"}   
-          Expenses:Depreciation    440 CNY
+          Expenses:Depreciation    440.00 CNY
 
         2020-04-30 * "Test-auto_depreciation"
           Assets:Fixed-Assets            -1 LENS {800.00 CNY, 2020-03-31}
           Assets:Fixed-Assets             1 LENS {207 CNY, 2020-04-30}
-          Expenses:Depreciation  593 CNY
+          Expenses:Depreciation  593.00 CNY
 
         2020-05-31 * "Test-auto_depreciation:Nikon"
           Assets:Fixed-Assets   -2 LENS {380 CNY, 2020-04-30, "Nikon"}
@@ -82,6 +82,73 @@ class TestExampleAutoDepreciation(cmptest.TestCase):
           Assets:Fixed-Assets  -2 LENS {243 CNY, 2020-05-31, "Nikon"}
           Assets:Fixed-Assets   2 LENS {200 CNY, 2020-06-30, "Nikon"}
           Expenses:Depreciation    86 CNY
+
+        """
+        self.assertEqualEntries(expected_entries, entries)
+        self.assertFalse(errors)
+
+    def test_rounding_errors(self):
+        sample = """
+        option "insert_pythonpath" "True"
+        plugin "auto_depreciation" "{
+          'assets':'Assets:Fixed-Assets',
+          'expenses':'Expenses:Depreciation',
+        }"
+
+        2020-03-01 open Assets:Cash CNY
+        2020-03-01 open Assets:Fixed-Assets
+        2020-03-01 open Expenses:Depreciation
+        2020-03-01 open Equity:Opening-Balances
+
+        2020-03-01 commodity LENS
+            name: "Camera lens"
+            assets-class: "fixed assets"
+
+        2020-03-01 * ""
+            Assets:Cash                     2999.85 CNY
+            Equity:Opening-Balances
+
+        2020-03-31 * "Test"
+            Assets:Cash                     -2999.85 CNY
+            Assets:Fixed-Assets        3 LENS {999.95 CNY, "Nikon"}
+              useful_life: "3m"
+              residual_value: 200.05
+        """
+        entries, errors, _ = loader.load_string(textwrap.dedent(sample))
+        expected_entries = """
+        2020-03-01 open Assets:Cash                                     CNY
+        2020-03-01 open Assets:Fixed-Assets
+        2020-03-01 open Expenses:Depreciation
+        2020-03-01 open Equity:Opening-Balances
+
+        2020-03-01 commodity LENS
+          assets-class: "fixed assets"
+          name: "Camera lens"
+
+        2020-03-01 * 
+          Assets:Cash               2999.85 CNY
+          Equity:Opening-Balances  -2999.85 CNY
+
+        2020-03-31 * "Test"
+          Assets:Cash              -2999.85 CNY
+          Assets:Fixed-Assets        3 LENS {999.95 CNY, 2020-03-31, "Nikon"}
+            useful_life: "3m"
+            residual_value: 200.05
+
+        2020-04-30 * "Test-auto_depreciation:Nikon"
+          Assets:Fixed-Assets   -3 LENS {999.95 CNY, 2020-03-31, "Nikon"}
+          Assets:Fixed-Assets    3 LENS {559 CNY, 2020-04-30, "Nikon"}
+          Expenses:Depreciation    1322.85 CNY
+
+        2020-05-31 * "Test-auto_depreciation:Nikon"
+          Assets:Fixed-Assets   -3 LENS {559 CNY, 2020-04-30, "Nikon"}
+          Assets:Fixed-Assets    3 LENS {287 CNY, 2020-05-31, "Nikon"}
+          Expenses:Depreciation    816 CNY
+
+        2020-06-30 * "Test-auto_depreciation:Nikon"
+          Assets:Fixed-Assets  -3 LENS {287 CNY, 2020-05-31, "Nikon"}
+          Assets:Fixed-Assets   3 LENS {200 CNY, 2020-06-30, "Nikon"}
+          Expenses:Depreciation    261 CNY
 
         """
         self.assertEqualEntries(expected_entries, entries)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This plugin currently converts start and end values from `Decimal` to `float` before doing any calculations. `float` is appropriate for generating the depreciation curves, but not for calculating the depreciation values that will go into the ledger. As a result, for many choices of start value, floating-point error causes this plugin to produce unbalanced transactions like the following:

```
2020-04-30 * "Test-auto_depreciation:Nikon"
  Assets:Fixed-Assets                               -3 LENS {999.95 CNY, 2020-03-31, "Nikon"}
  Assets:Fixed-Assets                                3 LENS {559 CNY, 2020-04-30, "Nikon"}
  Expenses:Depreciation  1322.850000000000136424205266 CNY
```

The fix is to keep the start and end values as `Decimal`s except when generating the depreciation curves.

## How was this patch tested?

Added an end-to-end test called `test_rounding_errors()` that previously failed and now passes.