### PR TITLE
Support beancount v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/hktkzyx/auto-depreciation"
 version = "3.1.1"
 
 [tool.poetry.dependencies]
-beancount = "^2.3.5"
+beancount = ">=2.3.5, <=4"
 mike = {version = "^1.1.2", optional = true}
 mkdocs = {version = "^1.2.3", optional = true}
 mkdocs-material = {version = "^8.2.1", optional = true}


### PR DESCRIPTION
Plugin works effortlessly, but pip fails to build wheel.

